### PR TITLE
Install jupyterlab

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ pip install -r requirements.txt
 
 If you don't want to use anaconda, you can use python3 and 
 ``` 
-pip install pandas jupyter barnum numpy matplotlib xlsxwriter seaborn bokeh jupyter parquet dask
+pip install pandas jupyter barnum numpy matplotlib xlsxwriter seaborn bokeh jupyterlab parquet dask
 ``` 
 (at your own risk)
 


### PR DESCRIPTION
The given "pip install" line installs jupyter twice but doesn't install jupyterlab.